### PR TITLE
Fix GHC-7.2 build by defining unsafeShiftL

### DIFF
--- a/Data/Memory/Internal/Compat.hs
+++ b/Data/Memory/Internal/Compat.hs
@@ -66,7 +66,7 @@ byteSwap16 w =
     (w `shiftR` 8) .|. (w `shiftL` 8)
 #endif
 
-#if !(MIN_VERSION_base(4,4,0))
+#if !(MIN_VERSION_base(4,5,0))
 unsafeShiftL :: Bits a => a -> Int -> a
 unsafeShiftL = shiftL
 


### PR DESCRIPTION
Currently memory builds on GHC-7.0 but not 7.2.
