### PR TITLE
For Review: Support for Base64 URL-safe encoding

### DIFF
--- a/Data/ByteArray/Encoding.hs
+++ b/Data/ByteArray/Encoding.hs
@@ -24,7 +24,8 @@ import           Data.Memory.Encoding.Base64
 -- | Different bases that can be used
 data Base = Base16 -- ^ similar to hexadecimal
           | Base32
-          | Base64
+          | Base64    -- ^ standard Base64
+          | Base64URL -- ^ unpadded URL-safe Base64
           deriving (Show,Eq)
 
 -- | Convert a bytearray to the equivalent representation in a specific Base
@@ -45,6 +46,12 @@ convertToBase Base64 b =
         toBase64 bout bin (B.length b)
   where (q,r)  = B.length b `divMod` 3
         outLen = 4 * (if r == 0 then q else q+1)
+convertToBase Base64URL b =
+    B.unsafeCreate outLen $ \bout ->
+    withByteArray b       $ \bin  ->
+        toBase64URL bout bin (B.length b)
+  where (q,r)  = B.length b `divMod` 3
+        outLen = 4 * q + (if r == 0 then 0 else r+1)
 
 -- | Try to Convert a bytearray from the equivalent representation in a specific Base
 convertFromBase :: (ByteArrayAccess bin, ByteArray bout) => Base -> bin -> Either String bout
@@ -78,3 +85,12 @@ convertFromBase Base64 b = unsafeDoIO $
                 case ret of
                     Nothing  -> return $ Right out
                     Just ofs -> return $ Left ("base64: input: invalid encoding at offset: " ++ show ofs)
+convertFromBase Base64URL b = unsafeDoIO $
+    withByteArray b $ \bin ->
+        case unBase64URLLength (B.length b) of
+            Nothing     -> return $ Left "base64URL: input: invalid length"
+            Just dstLen -> do
+                (ret, out) <- B.allocRet dstLen $ \bout -> fromBase64URL bout bin (B.length b)
+                case ret of
+                    Nothing  -> return $ Right out
+                    Just ofs -> return $ Left ("base64URL: input: invalid encoding at offset: " ++ show ofs)

--- a/Data/Memory/Encoding/Base64.hs
+++ b/Data/Memory/Encoding/Base64.hs
@@ -14,8 +14,11 @@
 {-# LANGUAGE Rank2Types        #-}
 module Data.Memory.Encoding.Base64
     ( toBase64
+    , toBase64URL
     , unBase64Length
+    , unBase64URLLength
     , fromBase64
+    , fromBase64URL
     ) where
 
 import           Control.Monad
@@ -37,6 +40,8 @@ toBase64 dst src len = loop 0 0
   where
         eqChar = 0x3d
 
+        !set = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"#
+
         loop i di
             | i >= len  = return ()
             | otherwise = do
@@ -44,7 +49,7 @@ toBase64 dst src len = loop 0 0
                 b <- if i + 1 >= len then return 0 else peekByteOff src (i+1)
                 c <- if i + 2 >= len then return 0 else peekByteOff src (i+2)
 
-                let (w,x,y,z) = convert3 a b c
+                let (w,x,y,z) = convert3 set a b c
 
                 pokeByteOff dst di     w
                 pokeByteOff dst (di+1) x
@@ -53,18 +58,37 @@ toBase64 dst src len = loop 0 0
 
                 loop (i+3) (di+4)
 
-convert3 :: Word8 -> Word8 -> Word8 -> (Word8, Word8, Word8, Word8)
-convert3 (W8# a) (W8# b) (W8# c) =
+toBase64URL :: Ptr Word8 -> Ptr Word8 -> Int -> IO ()
+toBase64URL dst src len = loop 0 0
+  where
+        !set = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"#
+
+        loop i di
+            | i >= len  = return ()
+            | otherwise = do
+                a <- peekByteOff src i
+                b <- if i + 1 >= len then return 0 else peekByteOff src (i+1)
+                c <- if i + 2 >= len then return 0 else peekByteOff src (i+2)
+
+                let (w,x,y,z) = convert3 set a b c
+
+                pokeByteOff dst di     w
+                pokeByteOff dst (di+1) x
+                unless (i + 1 >= len) $ pokeByteOff dst (di+2) y
+                unless (i + 2 >= len) $ pokeByteOff dst (di+3) z
+
+                loop (i+3) (di+4)
+
+convert3 :: Addr# -> Word8 -> Word8 -> Word8 -> (Word8, Word8, Word8, Word8)
+convert3 table (W8# a) (W8# b) (W8# c) =
     let !w = narrow8Word# (uncheckedShiftRL# a 2#)
         !x = or# (and# (uncheckedShiftL# a 4#) 0x30##) (uncheckedShiftRL# b 4#)
         !y = or# (and# (uncheckedShiftL# b 2#) 0x3c##) (uncheckedShiftRL# c 6#)
         !z = and# c 0x3f##
      in (index w, index x, index y, index z)
   where
-        !set = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"#
-
         index :: Word# -> Word8
-        index idx = W8# (indexWord8OffAddr# set (word2Int# idx))
+        index idx = W8# (indexWord8OffAddr# table (word2Int# idx))
 
 -- | Get the length needed for the destination buffer for a base64 decoding.
 --
@@ -82,6 +106,106 @@ unBase64Length src len
   where
         eqAscii :: Word8
         eqAscii = fromIntegral (fromEnum '=')
+
+unBase64URLLength :: Int -> Maybe Int
+unBase64URLLength len = case r of
+    0 -> Just (3*q)
+    2 -> Just (3*q + 1)
+    3 -> Just (3*q + 2)
+    _ -> Nothing
+  where (q, r) = len `divMod` 4
+
+fromBase64URL :: Ptr Word8 -> Ptr Word8 -> Int -> IO (Maybe Int)
+fromBase64URL dst src len = loop 0 0
+  where loop di i
+            | i == len       = return Nothing
+            | i == len - 2   = do
+                a <- peekByteOff src i
+                b <- peekByteOff src (i+1)
+
+                case decode2 a b of
+                    Left ofs -> return $ Just (i + ofs)
+                    Right x  -> do
+                        pokeByteOff dst di x
+                        return Nothing
+            | i == len - 3   = do
+                a <- peekByteOff src i
+                b <- peekByteOff src (i+1)
+                c <- peekByteOff src (i+2)
+
+                case decode3 a b c of
+                    Left ofs    -> return $ Just (i + ofs)
+                    Right (x,y) -> do
+                        pokeByteOff dst di     x
+                        pokeByteOff dst (di+1) y
+                        return Nothing
+            | otherwise      = do
+                a <- peekByteOff src i
+                b <- peekByteOff src (i+1)
+                c <- peekByteOff src (i+2)
+                d <- peekByteOff src (i+3)
+
+                case decode4 a b c d of
+                    Left ofs      -> return $ Just (i + ofs)
+                    Right (x,y,z) -> do
+                        pokeByteOff dst di     x
+                        pokeByteOff dst (di+1) y
+                        pokeByteOff dst (di+2) z
+                        loop (di + 3) (i + 4)
+
+        decode2 :: Word8 -> Word8 -> Either Int Word8
+        decode2 a b =
+            case (rset a, rset b) of
+                (0xff, _   ) -> Left 0
+                (_   , 0xff) -> Left 1
+                (ra  , rb  ) -> Right ((ra `unsafeShiftL` 2) .|. (rb `unsafeShiftR` 4))
+
+        decode3 :: Word8 -> Word8 -> Word8 -> Either Int (Word8, Word8)
+        decode3 a b c =
+            case (rset a, rset b, rset c) of
+                (0xff, _   , _   ) -> Left 0
+                (_   , 0xff, _   ) -> Left 1
+                (_   , _   , 0xff) -> Left 2
+                (ra  , rb  , rc  ) ->
+                    let x = (ra `unsafeShiftL` 2) .|. (rb `unsafeShiftR` 4)
+                        y = (rb `unsafeShiftL` 4) .|. (rc `unsafeShiftR` 2)
+                     in Right (x,y)
+
+
+        decode4 :: Word8 -> Word8 -> Word8 -> Word8 -> Either Int (Word8, Word8, Word8)
+        decode4 a b c d =
+            case (rset a, rset b, rset c, rset d) of
+                (0xff, _   , _   , _   ) -> Left 0
+                (_   , 0xff, _   , _   ) -> Left 1
+                (_   , _   , 0xff, _   ) -> Left 2
+                (_   , _   , _   , 0xff) -> Left 3
+                (ra  , rb  , rc  , rd  ) ->
+                    let x = (ra `unsafeShiftL` 2) .|. (rb `unsafeShiftR` 4)
+                        y = (rb `unsafeShiftL` 4) .|. (rc `unsafeShiftR` 2)
+                        z = (rc `unsafeShiftL` 6) .|. rd
+                     in Right (x,y,z)
+
+        rset :: Word8 -> Word8
+        rset (W8# w)
+            | booleanPrim (w `leWord#` 0xff##) = W8# (indexWord8OffAddr# rsetTable (word2Int# w))
+            | otherwise                        = 0xff
+
+        !rsetTable = "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\
+                     \\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\
+                     \\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\x3e\xff\xff\
+                     \\x34\x35\x36\x37\x38\x39\x3a\x3b\x3c\x3d\xff\xff\xff\xff\xff\xff\
+                     \\xff\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\
+                     \\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\xff\xff\xff\xff\x3f\
+                     \\xff\x1a\x1b\x1c\x1d\x1e\x1f\x20\x21\x22\x23\x24\x25\x26\x27\x28\
+                     \\x29\x2a\x2b\x2c\x2d\x2e\x2f\x30\x31\x32\x33\xff\xff\xff\xff\xff\
+                     \\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\
+                     \\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\
+                     \\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\
+                     \\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\
+                     \\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\
+                     \\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\
+                     \\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\
+                     \\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"#
 
 -- | convert from base64 in @src to binary in @dst, using the number of bytes specified
 --

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -60,6 +60,17 @@ base64Kats =
     , ("sure.", "c3VyZS4=")
     ]
 
+base64URLKats =
+    [ ("pleasure.", "cGxlYXN1cmUu")
+    , ("leasure.", "bGVhc3VyZS4")
+    , ("easure.", "ZWFzdXJlLg")
+    , ("asure.", "YXN1cmUu")
+    , ("sure.", "c3VyZS4")
+    , ("\DC4\251\156\ETX\217~", "FPucA9l-") -- From RFC4648
+    , ("\DC4\251\156\ETX\217\DEL", "FPucA9l_")
+    , ("", "")
+    ]
+
 base16Kats =
     [ ("this is a string", "74686973206973206120737472696e67") ]
 
@@ -82,6 +93,10 @@ encodingTests witnessID =
         [ testGroup "encode-KAT" encodeKats64
         , testGroup "decode-KAT" decodeKats64
         ]
+    , testGroup "BASE64URL"
+        [ testGroup "encode-KAT" encodeKats64URL
+        , testGroup "decode-KAT" decodeKats64URL
+        ]
     , testGroup "BASE32"
         [ testGroup "encode-KAT" encodeKats32
         , testGroup "decode-KAT" decodeKats32
@@ -98,6 +113,8 @@ encodingTests witnessID =
         decodeKats32 = map (toBackTest B.Base32) $ zip [1..] base32Kats
         encodeKats16 = map (toTest B.Base16) $ zip [1..] base16Kats
         decodeKats16 = map (toBackTest B.Base16) $ zip [1..] base16Kats
+        encodeKats64URL = map (toTest B.Base64URL) $ zip [1..] base64URLKats
+        decodeKats64URL = map (toBackTest B.Base64URL) $ zip [1..] base64URLKats
 
         toTest :: B.Base -> (Int, (String, String)) -> TestTree
         toTest base (i, (inp, out)) = testCase (show i) $

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -94,8 +94,8 @@ encodingTests witnessID =
         , testGroup "decode-KAT" decodeKats64
         ]
     , testGroup "BASE64URL"
-        [ testGroup "encode-KAT" encodeKats64URL
-        , testGroup "decode-KAT" decodeKats64URL
+        [ testGroup "encode-KAT" encodeKats64URLUnpadded
+        , testGroup "decode-KAT" decodeKats64URLUnpadded
         ]
     , testGroup "BASE32"
         [ testGroup "encode-KAT" encodeKats32
@@ -113,8 +113,8 @@ encodingTests witnessID =
         decodeKats32 = map (toBackTest B.Base32) $ zip [1..] base32Kats
         encodeKats16 = map (toTest B.Base16) $ zip [1..] base16Kats
         decodeKats16 = map (toBackTest B.Base16) $ zip [1..] base16Kats
-        encodeKats64URL = map (toTest B.Base64URL) $ zip [1..] base64URLKats
-        decodeKats64URL = map (toBackTest B.Base64URL) $ zip [1..] base64URLKats
+        encodeKats64URLUnpadded = map (toTest B.Base64URLUnpadded) $ zip [1..] base64URLKats
+        decodeKats64URLUnpadded = map (toBackTest B.Base64URLUnpadded) $ zip [1..] base64URLKats
 
         toTest :: B.Base -> (Int, (String, String)) -> TestTree
         toTest base (i, (inp, out)) = testCase (show i) $


### PR DESCRIPTION
Adds 'Base64URL' to the 'Base' data type. Calling convertToBase
with this value implements unpadded URL-safe encoding as used in
various standards (such as the JOSE RFCs).

This probably isn't ready for merging as it is, because it is mostly duplicated from the existing Base64 code and could probably be refactored to share a lot of the code. However, I don't have a lot of experience with low-level Haskell code, so I'm cautious about proceeding. It appears to work OK as I've run it with all my jose-jwt library tests as well as the few I added to the codebase itself.

The only change to the existing code is passing the encoding alphabet as a parameter to the `convert3` function, so that it can be shared.

The decoding function differs mainly in the fact that it doesn't use padding. This is really a separate concern from the decoding table used, so it would be possible to have `decodePadded` and `decodeUnpadded` functions which were parameterized with the decoding table.

What do you think?
