### PR TITLE
Remove unnecessary foundation build-depends

### DIFF
--- a/memory.cabal
+++ b/memory.cabal
@@ -71,7 +71,6 @@ Library
                      Data.ByteArray.MemView
                      Data.ByteArray.View
   Build-depends:     base >= 4 && < 5
-                   , foundation
                    , ghc-prim
   -- FIXME armel or mispel is also little endian.
   -- might be a good idea to also add a runtime autodetect mode.


### PR DESCRIPTION
`foundation` seems to have mistakenly been included in b2037c305b5ce6f0971a0f291a07b70aac73b5a3. It doesn't appear to be necessary.