### PR TITLE
Fix instance Show Bytes

### DIFF
--- a/Data/ByteArray/Bytes.hs
+++ b/Data/ByteArray/Bytes.hs
@@ -154,7 +154,7 @@ bytesUnpackChars (Bytes mba) xs = chunkLoop 0#
     chunkLoop idx
         | booleanPrim (len ==# idx) = []
         | booleanPrim ((len -# idx) ># 63#) =
-            bytesLoop idx (idx +# 64#) (chunkLoop (idx +# 64#))
+            bytesLoop idx 64# (chunkLoop (idx +# 64#))
         | otherwise =
             bytesLoop idx (len -# idx) xs
 


### PR DESCRIPTION
Function `bytesUnpackChars` reads at indices after the end of the bytearray.
This should fix the issue reported in haskell-crypto/cryptonite#127.