### PR TITLE
Word128 instance definitions

### DIFF
--- a/Data/Memory/ExtendedWords.hs
+++ b/Data/Memory/ExtendedWords.hs
@@ -96,7 +96,7 @@ instance Enum Word128 where
     | x /= minBound = x - 1
     | otherwise     = predError "Word128"
   toEnum x
-    | x >= 0        = fromInteger $ toInteger x -- More efficient without going through integer?
+    | x >= 0        = fromInteger $ toInteger x
     | otherwise     = toEnumError "Word128" x (minBound::Word128, maxBound::Word128)
   fromEnum x
     | x <= fromIntegral (maxBound::Int)

--- a/Data/Memory/ExtendedWords.hs
+++ b/Data/Memory/ExtendedWords.hs
@@ -12,6 +12,106 @@ module Data.Memory.ExtendedWords
     ) where
 
 import Data.Word (Word64)
+import Data.Bits
+import Data.Ratio ((%))
+import GHC.Enum
 
 -- | A simple Extended Word128 composed of 2 Word64
 data Word128 = Word128 !Word64 !Word64 deriving (Show, Eq)
+
+applyToParts :: (Word64 -> Word64 -> Word64) -> Word128 -> Word128 -> Word128
+applyToParts opp (Word128 w64w1p1 w64w1p2) (Word128 w64w2p1 w64w2p2) =
+  Word128 (w64w1p1 `opp` w64w2p1) (w64w1p2 `opp` w64w2p2)
+
+instance Bits Word128 where
+  (.&.) = applyToParts (.&.)
+  (.|.) = applyToParts (.|.)
+  xor = applyToParts xor
+  complement (Word128 w64p1 w64p2) = Word128 (complement w64p1) (complement w64p2)
+  shiftL (Word128 w64p1 w64p2) shiftCount
+    | shiftCount < 0 = minBound
+    | shiftCount > 64 = shiftL (Word128 w64p2 0) (shiftCount - 64)
+    | otherwise = Word128 mostSignificant leastSignificant
+      where leastSignificant = shiftL w64p2 shiftCount
+            w64overflow = shiftR w64p2 (64 - shiftCount)
+            mostSignificant = shiftL w64p1 shiftCount .|. w64overflow
+  shiftR (Word128 w64p1 w64p2) shiftCount
+    | shiftCount < 0 = minBound
+    | shiftCount > 64 = shiftR (Word128 0 w64p1) (shiftCount - 64)
+    | otherwise = Word128 mostSignificant leastSignificant
+      where mostSignificant = shiftR w64p1 shiftCount
+            w64overflow = shiftL w64p1 (64 - shiftCount)
+            leastSignificant = w64overflow .|. shiftR w64p2 shiftCount
+  rotateL w128 rotateCount
+    | rotateCount < 0 = minBound
+    | rotateCount > 128 = rotateL w128 (rotateCount `mod` 128)
+    | otherwise = shifted .|. overflow
+      where overflow = shiftR w128 (128 - rotateCount)
+            shifted = shiftL w128 rotateCount
+  rotateR w128 rotateCount
+    | rotateCount < 0 = Word128 0 0
+    | rotateCount > 128 = rotateR w128 (rotateCount `mod` 128)
+    | otherwise = overflow .|. shifted
+      where overflow = shiftL w128 (128 - rotateCount)
+            shifted = shiftR w128 rotateCount
+  bitSize = finiteBitSize
+  bitSizeMaybe = Just . finiteBitSize
+  isSigned _ = False
+  testBit = testBitDefault
+  bit = bitDefault
+  popCount (Word128 w64p1 w64p2) = popCount w64p1 + popCount w64p2
+
+instance FiniteBits Word128 where
+  finiteBitSize _ = 128
+
+instance Bounded Word128 where
+  minBound = Word128 minBound minBound
+  maxBound = Word128 maxBound maxBound
+
+instance Ord Word128 where
+  (<=) (Word128 w64w1p1 w64w1p2) (Word128 w64w2p1 w64w2p2)
+    | w64w1p1 < w64w2p1 = True
+    | w64w1p1 == w64w2p1 && w64w1p2 <= w64w2p2 = True
+    | otherwise = False
+
+instance Num Word128 where
+  fromInteger integer = let w64p1 = fromIntegral $ shiftR integer 64 :: Word64
+                            w64p2 = fromIntegral integer :: Word64
+                        in Word128 w64p1 w64p2
+  (+) w1 w2 = fromInteger $ toInteger w1 + toInteger w2
+  (*) w1 w2 = fromInteger $ toInteger w1 * toInteger w2
+  abs x = x
+  signum 0 = 0
+  signum _ = 1
+  negate x = maxBound - x + 1
+
+instance Real Word128 where
+  toRational x = toInteger x % 1
+
+instance Enum Word128 where
+  succ x
+    | x /= maxBound = x + 1
+    | otherwise     = succError "Word128"
+  pred x
+    | x /= minBound = x - 1
+    | otherwise     = predError "Word128"
+  toEnum x
+    | x >= 0        = fromInteger $ toInteger x -- More efficient without going through integer?
+    | otherwise     = toEnumError "Word128" x (minBound::Word128, maxBound::Word128)
+  fromEnum x
+    | x <= fromIntegral (maxBound::Int)
+                    = fromInteger $ toInteger x
+    | otherwise     = fromEnumError "Word128" x
+  enumFrom x        = enumFromTo x maxBound
+  enumFromThen x y  = enumFromThenTo x y bound
+    where
+      bound | fromEnum y >= fromEnum x = maxBound
+            | otherwise                = minBound
+
+instance Integral Word128 where
+  toInteger (Word128 w64p1 w61p2) = shiftL (fromIntegral w64p1) 64 + fromIntegral w61p2
+  quot w1 w2 = fromInteger $ toInteger w1 `quot` toInteger w2
+  rem w1 w2 = fromInteger $ toInteger w1 `rem` toInteger w2
+  quotRem w1 w2 = (w1 `quot` w2, w1 `rem` w2)
+  div = quot
+  mod = rem

--- a/tests/ExtendedWords.hs
+++ b/tests/ExtendedWords.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module ExtendedWords where
+
+import           Imports
+import           Utils
+import           Data.Bits
+import           Data.Memory.ExtendedWords
+
+
+instance Arbitrary Word128 where
+  arbitrary = do
+    a1 <- arbitrary
+    a2 <- arbitrary
+    return $ Word128 a1 a2
+
+
+-- w128toInteger :: Word128 -> Integer
+-- w128toInteger (Word128 w64p1 w61p2) = shiftL (fromIntegral w64p1) 64 + fromIntegral w61p2
+
+w128properties = testGroup "Word 128 Properties"
+  [ testProperty "complement . complement = id" $ \(w128 :: Word128) -> w128 == (complement . complement $ w128)
+  , testProperty "rotateR (rotateL A x) x = id" $
+      \(w128 :: Word128, Positive rotateCount) -> w128 == rotateR (rotateL w128 rotateCount) rotateCount
+  , testProperty "abs x * signum x == x" $ \(w128 :: Word128) -> w128 == (abs w128 * signum w128)
+  , testProperty "(x `quot` y)*y + (x `rem` y) == x" $
+      \(Positive (w1 :: Word128), Positive (w2 :: Word128)) -> w1 == ((w1 `quot` w2) * w2 + (w1 `rem` w2))
+  , testProperty "(x `div` y)*y + (x `mod` y) == x" $
+      \(Positive (w1 :: Word128), Positive (w2 :: Word128)) -> w1 == ((w1 `div` w2) * w2 + (w1 `mod` w2))
+  , testProperty "fromInteger . toInteger = id" $ \(w128 :: Word128) -> w128 == (fromInteger . toInteger $ w128)]

--- a/tests/ExtendedWords.hs
+++ b/tests/ExtendedWords.hs
@@ -15,9 +15,6 @@ instance Arbitrary Word128 where
     return $ Word128 a1 a2
 
 
--- w128toInteger :: Word128 -> Integer
--- w128toInteger (Word128 w64p1 w61p2) = shiftL (fromIntegral w64p1) 64 + fromIntegral w61p2
-
 w128properties = testGroup "Word 128 Properties"
   [ testProperty "complement . complement = id" $ \(w128 :: Word128) -> w128 == (complement . complement $ w128)
   , testProperty "rotateR (rotateL A x) x = id" $

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -12,6 +12,7 @@ import qualified Data.ByteArray.Encoding as B
 import qualified Data.ByteArray.Parse    as Parse
 
 import qualified SipHash
+import qualified ExtendedWords
 
 data Backend = BackendByte | BackendScrubbedBytes
     deriving (Show,Eq,Bounded,Enum)
@@ -161,7 +162,7 @@ main = defaultMain $ testGroup "memory"
         ]
     , testShowProperty "showing" $ \witnessID expectedShow (Words8 l) ->
           (show . witnessID . B.pack $ l) == expectedShow l
-    ]
+    , ExtendedWords.w128properties]
   where
     basicProperties witnessID =
         [ testProperty "unpack . pack == id" $ \(Words8 l) -> l == (B.unpack . witnessID . B.pack $ l)


### PR DESCRIPTION
I noticed this implementation of `Word128` is currently used by `cryptonite`. I'd like to port an existing pure haskell implementation of the Twofish block cipher from Hackage to `cryptonite`. These instance definitions would make this `Word128` implementation much easier to work with for that project.