### PR TITLE
Fix use of touch# on GHC 8.2

### DIFF
--- a/Data/ByteArray/ScrubbedBytes.hs
+++ b/Data/ByteArray/ScrubbedBytes.hs
@@ -73,12 +73,7 @@ newScrubbedBytes (I# sz)
                  in case mkWeak# mbarr () (finalize scrubber mba) s1 of
                     (# s2, _ #) -> (# s2, mba #)
   where
-#if __GLASGOW_HASKELL__ > 801
-    finalize :: (State# RealWorld -> State# RealWorld) -> ScrubbedBytes -> State# RealWorld -> State# RealWorld
-    finalize scrubber mba@(ScrubbedBytes _) = \s1 ->
-        case scrubber s1 of
-            s2 -> touch# mba s2
-#elif __GLASGOW_HASKELL__ >= 800
+#if __GLASGOW_HASKELL__ >= 800
     finalize :: (State# RealWorld -> State# RealWorld) -> ScrubbedBytes -> State# RealWorld -> (# State# RealWorld, () #)
     finalize scrubber mba@(ScrubbedBytes _) = \s1 ->
         case scrubber s1 of


### PR DESCRIPTION
It's not entirely clear why the `__GLASGOW_HASKELL__ > 801` case existed, but
removing it is correct and nicely simplifies things.