### PR TITLE
bump Foundation dependency minimal version

### DIFF
--- a/Data/ByteArray/Types.hs
+++ b/Data/ByteArray/Types.hs
@@ -55,7 +55,7 @@ uarrayRecastW8 :: F.PrimType ty => F.UArray ty -> F.UArray F.Word8
 uarrayRecastW8 = F.recast
 
 instance F.PrimType ty => ByteArrayAccess (F.UArray ty) where
-#if MIN_VERSION_foundation(0,0,9)
+#if MIN_VERSION_foundation(0,0,10)
     length a = let F.CountOf i = F.length (uarrayRecastW8 a) in i
 #else
     length = F.length . uarrayRecastW8
@@ -63,7 +63,7 @@ instance F.PrimType ty => ByteArrayAccess (F.UArray ty) where
     withByteArray a f = F.withPtr (uarrayRecastW8 a) (f . castPtr)
 
 instance ByteArrayAccess F.String where
-#if MIN_VERSION_foundation(0,0,9)
+#if MIN_VERSION_foundation(0,0,10)
     length str = let F.CountOf i = F.length str in i
 #else
     length = F.length
@@ -72,7 +72,7 @@ instance ByteArrayAccess F.String where
 
 instance (Ord ty, F.PrimType ty) => ByteArray (F.UArray ty) where
     allocRet sz f = do
-#if MIN_VERSION_foundation(0,0,9)
+#if MIN_VERSION_foundation(0,0,10)
         mba <- F.new (F.CountOf sz)
 #else
         mba <- F.new (F.Size sz)

--- a/Data/ByteArray/Types.hs
+++ b/Data/ByteArray/Types.hs
@@ -55,16 +55,28 @@ uarrayRecastW8 :: F.PrimType ty => F.UArray ty -> F.UArray F.Word8
 uarrayRecastW8 = F.recast
 
 instance F.PrimType ty => ByteArrayAccess (F.UArray ty) where
+#if MIN_VERSION_foundation(0,0,9)
     length a = let F.CountOf i = F.length (uarrayRecastW8 a) in i
+#else
+    length = F.length . uarrayRecastW8
+#endif
     withByteArray a f = F.withPtr (uarrayRecastW8 a) (f . castPtr)
 
 instance ByteArrayAccess F.String where
+#if MIN_VERSION_foundation(0,0,9)
     length str = let F.CountOf i = F.length str in i
+#else
+    length = F.length
+#endif
     withByteArray s f = withByteArray (F.toBytes F.UTF8 s) f
 
 instance (Ord ty, F.PrimType ty) => ByteArray (F.UArray ty) where
     allocRet sz f = do
+#if MIN_VERSION_foundation(0,0,9)
         mba <- F.new (F.CountOf sz)
+#else
+        mba <- F.new (F.Size sz)
+#endif
         a   <- F.withMutablePtr mba (f . castPtr)
         ba  <- F.unsafeFreeze mba
         return (a, ba)

--- a/Data/ByteArray/Types.hs
+++ b/Data/ByteArray/Types.hs
@@ -55,16 +55,16 @@ uarrayRecastW8 :: F.PrimType ty => F.UArray ty -> F.UArray F.Word8
 uarrayRecastW8 = F.recast
 
 instance F.PrimType ty => ByteArrayAccess (F.UArray ty) where
-    length = F.length . uarrayRecastW8
+    length a = let F.CountOf i = F.length (uarrayRecastW8 a) in i
     withByteArray a f = F.withPtr (uarrayRecastW8 a) (f . castPtr)
 
 instance ByteArrayAccess F.String where
-    length = F.length
+    length str = let F.CountOf i = F.length str in i
     withByteArray s f = withByteArray (F.toBytes F.UTF8 s) f
 
 instance (Ord ty, F.PrimType ty) => ByteArray (F.UArray ty) where
     allocRet sz f = do
-        mba <- F.new (F.Size sz)
+        mba <- F.new (F.CountOf sz)
         a   <- F.withMutablePtr mba (f . castPtr)
         ba  <- F.unsafeFreeze mba
         return (a, ba)

--- a/memory.cabal
+++ b/memory.cabal
@@ -96,7 +96,7 @@ Library
     Build-depends:   deepseq >= 1.1
   if flag(support_foundation)
     CPP-options:     -DWITH_FOUNDATION_SUPPORT
-    Build-depends:   foundation >= 0.0.8
+    Build-depends:   foundation >= 0.0.10
 
   ghc-options:       -Wall -fwarn-tabs
   default-language:  Haskell2010

--- a/memory.cabal
+++ b/memory.cabal
@@ -115,3 +115,6 @@ Test-Suite test-memory
                    , memory
   ghc-options:       -Wall -fno-warn-orphans -fno-warn-missing-signatures -threaded
   default-language:  Haskell2010
+  if flag(support_foundation)
+    CPP-options:     -DWITH_FOUNDATION_SUPPORT
+    Build-depends:   foundation >= 0.0.8

--- a/memory.cabal
+++ b/memory.cabal
@@ -96,7 +96,7 @@ Library
     Build-depends:   deepseq >= 1.1
   if flag(support_foundation)
     CPP-options:     -DWITH_FOUNDATION_SUPPORT
-    Build-depends:   foundation >= 0.0.10
+    Build-depends:   foundation >= 0.0.8
 
   ghc-options:       -Wall -fwarn-tabs
   default-language:  Haskell2010

--- a/memory.cabal
+++ b/memory.cabal
@@ -19,7 +19,7 @@ License:             BSD3
 License-file:        LICENSE
 Copyright:           Vincent Hanquez <vincent@snarc.org>
 Author:              Vincent Hanquez <vincent@snarc.org>
-Maintainer:          vincent@snarc.org
+Maintainer:          vincent@snarc.org, Nicolas Di Prima <nicolas@primetype.co.uk>
 Category:            memory
 Stability:           experimental
 Build-Type:          Simple

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,4 +2,4 @@ resolver: lts-8.12
 packages:
 - .
 extra-deps:
-- foundation-0.0.8
+- foundation-0.0.10


### PR DESCRIPTION
fix #33 
fix #32 

Since #haskell-foundation/foundation version 0.0.10 we have replaced `Size a` by `CountOf a`.
Also, now Foundation's `Collection` class's function `length` returns a `CountOf (Element col)`.
