### PR TITLE
Fix compilation with foundation-0.0.14

### DIFF
--- a/Data/ByteArray/Types.hs
+++ b/Data/ByteArray/Types.hs
@@ -25,7 +25,7 @@ import qualified Foundation as F
 import qualified Foundation.Collection as F
 import qualified Foundation.String as F (toBytes, Encoding(UTF8))
 import qualified Foundation.Array.Internal as F
-import qualified Foundation.Primitive as F
+import qualified Foundation.Primitive as F (primSizeInBytes)
 #endif
 
 -- | Class to Access size properties and data of a ByteArray


### PR DESCRIPTION
Now that `AsciiString` is exported from `Foundation.Primitive` we have this compilation error:

```
Data/ByteArray/Types.hs:81:17: error:
    Ambiguous occurrence ‘F.toBytes’
    It could refer to either ‘F.toBytes’,
                             imported qualified from ‘Foundation.String’ at Data/ByteArray/Types.hs:26:42-48
                             (and originally defined in ‘basement-0.0.1:Basement.String’)
                          or ‘F.toBytes’,
                             imported qualified from ‘Foundation.Primitive’ at Data/ByteArray/Types.hs:28:1-42
                             (and originally defined in ‘basement-0.0.1:Basement.Types.AsciiString’)
```
