### PR TITLE
Fix segfault when calling 'convertFromBase Base64' on BS with len 0

### DIFF
--- a/Data/Memory/Encoding/Base64.hs
+++ b/Data/Memory/Encoding/Base64.hs
@@ -104,6 +104,7 @@ convert3 table (W8# a) (W8# b) (W8# c) =
 -- if the length is not a multiple of 4, Nothing is returned
 unBase64Length :: Ptr Word8 -> Int -> IO (Maybe Int)
 unBase64Length src len
+    | len < 1            = return Nothing
     | (len `mod` 4) /= 0 = return Nothing
     | otherwise          = do
         last1Byte <- peekByteOff src (len - 1)


### PR DESCRIPTION
Hi @vincenthz, per our conversation last night. We found this code can segfault due to `peekByteOff` with a negative index with:

```haskell
unBase64Length ptr 0
```

This patch fixes the bounds check so it returns `Nothing` instead of segfaulting. 