### PR TITLE
Add `base >= 4.8` lowerbound

### DIFF
--- a/memory.cabal
+++ b/memory.cabal
@@ -75,7 +75,7 @@ Library
                      Data.ByteArray.Methods
                      Data.ByteArray.MemView
                      Data.ByteArray.View
-  Build-depends:     base >= 4 && < 5
+  Build-depends:     base >= 4.8 && < 5
                    , ghc-prim
   -- FIXME armel or mispel is also little endian.
   -- might be a good idea to also add a runtime autodetect mode.


### PR DESCRIPTION
The GHC-7.8 isn't tested on CI, so better not speculate that GHC-7.8 is supported.

*EDIT* README needs update as well, https://github.com/vincenthz/hs-memory#support