### PR TITLE
Isomorphism of base64 conversions on empty string is broken in 0.14.13

### DIFF
--- a/Data/Memory/Encoding/Base64.hs
+++ b/Data/Memory/Encoding/Base64.hs
@@ -104,7 +104,7 @@ convert3 table (W8# a) (W8# b) (W8# c) =
 -- if the length is not a multiple of 4, Nothing is returned
 unBase64Length :: Ptr Word8 -> Int -> IO (Maybe Int)
 unBase64Length src len
-    | len < 1            = return Nothing
+    | len < 1            = return $ Just 0
     | (len `mod` 4) /= 0 = return Nothing
     | otherwise          = do
         last1Byte <- peekByteOff src (len - 1)

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -92,6 +92,7 @@ base64Kats =
     , ("easure.", "ZWFzdXJlLg==")
     , ("asure.", "YXN1cmUu")
     , ("sure.", "c3VyZS4=")
+    , ("", "")
     ]
 
 base64URLKats =


### PR DESCRIPTION
Not isomorphic between `from' and `to' conversions on empty string.

```haskell
ghci> :set -XOverloadedStrings
ghci> import Data.ByteString
ghci> import Data.ByteArray.Encoding
ghci> convertToBase Base64 Data.ByteString.empty :: ByteString
""
ghci> convertFromBase Base64 Data.ByteString.empty :: Either String ByteString
Left "base64: input: invalid length"
```
