### PR TITLE
The implementation of base32 has the same segfault issue on zero length BS

### DIFF
--- a/Data/Memory/Encoding/Base32.hs
+++ b/Data/Memory/Encoding/Base32.hs
@@ -111,6 +111,7 @@ toBase32Per5Bytes (W8# i1, W8# i2, W8# i3, W8# i4, W8# i5) =
 -- if the length is not a multiple of 8, Nothing is returned
 unBase32Length :: Ptr Word8 -> Int -> IO (Maybe Int)
 unBase32Length src len
+    | len < 1            = return $ Just 0
     | (len `mod` 8) /= 0 = return Nothing
     | otherwise          = do
         last1Byte <- peekByteOff src (len - 1)
@@ -250,4 +251,3 @@ fromBase32Per8Bytes (i1, i2, i3, i4, i5, i6, i7, i8) =
                  \\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\
                  \\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\
                  \\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF"#
-


### PR DESCRIPTION
Like #42, I found a segfault issue on `convertFromBase Base32' with zero length ByteString.

```haskell
ghci> :set -XOverloadedStrings
ghci> import Data.ByteString
ghci> import Data.ByteArray.Encoding
ghci> convertFromBase Base32 Data.ByteString.empty :: Either String ByteString
Segmentation fault (core dumped)
```
