### PR TITLE
The base32 encoder has segfault or buffer overrun issue

### DIFF
--- a/Data/Memory/Encoding/Base32.hs
+++ b/Data/Memory/Encoding/Base32.hs
@@ -58,7 +58,7 @@ toBase32 dst src len = loop 0 0
          -> Int -- index output
          -> IO ()
     loop i di
-        | i >  len  = return ()
+        | i >= len  = return ()
         | otherwise = do
             i1 <- peekByteOff src i
             i2 <- peekOrZero (i + 1)
@@ -250,4 +250,3 @@ fromBase32Per8Bytes (i1, i2, i3, i4, i5, i6, i7, i8) =
                  \\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\
                  \\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\
                  \\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF"#
-

--- a/memory.cabal
+++ b/memory.cabal
@@ -110,6 +110,7 @@ Test-Suite test-memory
                      SipHash
                      Utils
   Build-Depends:     base >= 3 && < 5
+                   , bytestring
                    , tasty
                    , tasty-quickcheck
                    , tasty-hunit


### PR DESCRIPTION
I found a buffer overrun issue on `convertToBase Base32'.
A typical example is below:

```haskell
ghci> :set -XOverloadedStrings
ghci> import Data.ByteString
ghci> import Data.ByteArray.Encoding
ghci> convertToBase Base32 Data.ByteString.empty :: ByteString
"Segmentation fault (core dumped)
```
