### PR TITLE
Reversing a bytearray

### DIFF
--- a/Data/ByteArray/Methods.hs
+++ b/Data/ByteArray/Methods.hs
@@ -211,7 +211,7 @@ concat l = unsafeCreate retLen (loopCopy l)
 
     loopCopy []     _   = return ()
     loopCopy (x:xs) dst = do
-        withByteArray x $ \src -> memCopy dst src chunkLen
+        copyByteArrayToPtr x dst
         loopCopy xs (dst `plusPtr` chunkLen)
       where
         !chunkLen = length x
@@ -224,14 +224,14 @@ append = mappend
 copy :: (ByteArrayAccess bs1, ByteArray bs2) => bs1 -> (Ptr p -> IO ()) -> IO bs2
 copy bs f =
     alloc (length bs) $ \d -> do
-        withByteArray bs $ \s -> memCopy d s (length bs)
+        copyByteArrayToPtr bs d
         f (castPtr d)
 
 -- | Similar to 'copy' but also provide a way to return a value from the initializer
 copyRet :: (ByteArrayAccess bs1, ByteArray bs2) => bs1 -> (Ptr p -> IO a) -> IO (a, bs2)
 copyRet bs f =
     allocRet (length bs) $ \d -> do
-        withByteArray bs $ \s -> memCopy d s (length bs)
+        copyByteArrayToPtr bs d
         f (castPtr d)
 
 -- | Similiar to 'copy' but expect the resulting bytearray in a pure context

--- a/Data/ByteArray/Methods.hs
+++ b/Data/ByteArray/Methods.hs
@@ -26,6 +26,7 @@ module Data.ByteArray.Methods
     , take
     , drop
     , span
+    , reverse
     , convert
     , copyRet
     , copyAndFreeze
@@ -48,7 +49,7 @@ import           Data.Monoid
 import           Foreign.Storable
 import           Foreign.Ptr
 
-import           Prelude hiding (length, take, drop, span, concat, replicate, splitAt, null, pred, last, any, all)
+import           Prelude hiding (length, take, drop, span, reverse, concat, replicate, splitAt, null, pred, last, any, all)
 import qualified Prelude
 
 #if defined(WITH_BYTESTRING_SUPPORT) && defined(WITH_FOUNDATION_SUPPORT)
@@ -196,6 +197,11 @@ span pred bs
             | pred (index bs i) = loop (i+1)
             | otherwise         = i
         len = length bs
+
+-- | Reverse a bytearray
+reverse :: ByteArray bs => bs -> bs
+reverse bs = unsafeCreate n $ \d -> withByteArray bs $ \s -> memReverse d s n
+  where n = length bs
 
 -- | Concatenate bytearray into a larger bytearray
 concat :: (ByteArrayAccess bin, ByteArray bout) => [bin] -> bout

--- a/Data/Memory/PtrMethods.hs
+++ b/Data/Memory/PtrMethods.hs
@@ -17,6 +17,7 @@ module Data.Memory.PtrMethods
     , memXorWith
     , memCopy
     , memSet
+    , memReverse
     , memEqual
     , memConstEqual
     , memCompare
@@ -71,6 +72,14 @@ memCopy dst src n = c_memcpy dst src (fromIntegral n)
 memSet :: Ptr Word8 -> Word8 -> Int -> IO ()
 memSet start v n = c_memset start v (fromIntegral n) >>= \_ -> return ()
 {-# INLINE memSet #-}
+
+-- | Reverse a set number of bytes from @src@ to @dst@.  Memory
+-- locations should not overlap.
+memReverse :: Ptr Word8 -> Ptr Word8 -> Int -> IO ()
+memReverse d s n
+    | n > 0 = do peekByteOff s (n - 1) >>= poke d
+                 memReverse (d `plusPtr` 1) s (n - 1)
+    | otherwise = return ()
 
 -- | Check if two piece of memory are equals
 memEqual :: Ptr Word8 -> Ptr Word8 -> Int -> IO Bool

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -251,11 +251,12 @@ main = defaultMain $ Group "memory"
             let chunks   = fmap (witnessID . B.pack . unWords8) l
                 expected = concatMap unWords8 l
              in B.pack expected == witnessID (B.concat chunks)
-        , Property "cons b bs == reverse (snoc (reverse bs) b)" $ \(Words8 l) b ->
-            let b1 = witnessID (B.pack l)
-                b2 = witnessID (B.pack (reverse l))
-                expected = B.pack (reverse (B.unpack (B.snoc b2 b)))
-             in B.cons b b1 == expected
+        , Property "reverse" $ \(Words8 l) ->
+            let b = witnessID (B.pack l)
+             in reverse l == B.unpack (B.reverse b)
+        , Property "cons b (reverse bs) == reverse (snoc bs b)" $ \(Words8 l) b ->
+            let a = witnessID (B.pack l)
+             in B.cons b (B.reverse a) == B.reverse (B.snoc a b)
         , Property "all == Prelude.all" $ \(Words8 l) b ->
             let b1 = witnessID (B.pack l)
                 p  = (/= b)


### PR DESCRIPTION
Adding function `reverse` can be useful to swap between big and little endian representation of numbers. And it gives nice symmetry to the test case with cons/snoc.

PR also adds more calls to copyByteArrayToPtr.