### PR TITLE
Use memset and memcpy from ByteString to avoid issues with llvm-ng backend

### DIFF
--- a/Data/Memory/PtrMethods.hs
+++ b/Data/Memory/PtrMethods.hs
@@ -28,7 +28,6 @@ import           Foreign.Storable         (peek, poke, peekByteOff)
 import           Foreign.C.Types
 import           Foreign.Marshal.Alloc    (allocaBytesAligned)
 import           Data.Bits                ((.|.), xor)
-import           Data.ByteString.Internal (memset, memcpy)
 
 -- | Create a new temporary buffer
 memCreateTemporary :: Int -> (Ptr Word8 -> IO a) -> IO a
@@ -65,12 +64,12 @@ memXorWith destination !v source bytes
 
 -- | Copy a set number of bytes from @src to @dst
 memCopy :: Ptr Word8 -> Ptr Word8 -> Int -> IO ()
-memCopy = memcpy
+memCopy dst src n = c_memcpy dst src (fromIntegral n) >> return ()
 {-# INLINE memCopy #-}
 
 -- | Set @n number of bytes to the same value @v
 memSet :: Ptr Word8 -> Word8 -> Int -> IO ()
-memSet start v n = memset start v (fromIntegral n) >> return ()
+memSet start v n =  c_memset start (fromIntegral v) (fromIntegral n) >> return ()
 {-# INLINE memSet #-}
 
 -- | Check if two piece of memory are equals
@@ -106,3 +105,10 @@ memConstEqual p1 p2 n = loop 0 0
         | otherwise = do
             e <- xor <$> peekByteOff p1 i <*> (peekByteOff p2 i :: IO Word8)
             loop (i+1) (acc .|. e)
+
+
+foreign import ccall unsafe "string.h memset"
+    c_memset :: Ptr Word8 -> CInt -> CSize -> IO (Ptr Word8)
+
+foreign import ccall unsafe "string.h memcpy"
+    c_memcpy :: Ptr Word8 -> Ptr Word8 -> CSize -> IO (Ptr Word8)

--- a/Data/Memory/PtrMethods.hs
+++ b/Data/Memory/PtrMethods.hs
@@ -7,6 +7,7 @@
 --
 -- methods to manipulate raw memory representation
 --
+{-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE UnboxedTuples #-}
@@ -106,8 +107,8 @@ memConstEqual p1 p2 n = loop 0 0
             e <- xor <$> peekByteOff p1 i <*> (peekByteOff p2 i :: IO Word8)
             loop (i+1) (acc .|. e)
 
-foreign import ccall unsafe "memset"
+foreign import capi "string.h memset"
     c_memset :: Ptr Word8 -> Word8 -> CSize -> IO ()
 
-foreign import ccall unsafe "memcpy"
+foreign import capi "string.h memcpy"
     c_memcpy :: Ptr Word8 -> Ptr Word8 -> CSize -> IO ()


### PR DESCRIPTION
This is the same issue that @angerman tackled in Foundation, where the ccall was causing a `ghc: panic!`. I've made similar changes that he made in his https://github.com/haskell-foundation/foundation/pull/420 PR, which fixes the issue for me.