### PR TITLE
Remove allocations from memXorWith

### DIFF
--- a/Data/Memory/Encoding/Base64.hs
+++ b/Data/Memory/Encoding/Base64.hs
@@ -26,7 +26,6 @@ module Data.Memory.Encoding.Base64
     , fromBase64OpenBSD
     ) where
 
-import           Control.Monad
 import           Data.Memory.Internal.Compat
 import           Data.Memory.Internal.CompatPrim
 import           Data.Memory.Internal.Imports

--- a/Data/Memory/Internal/Imports.hs
+++ b/Data/Memory/Internal/Imports.hs
@@ -12,6 +12,6 @@ module Data.Memory.Internal.Imports
 
 import Data.Word                    as X
 import Control.Applicative          as X
-import Control.Monad                as X (forM, forM_, void)
+import Control.Monad                as X (forM, forM_, void, when)
 import Control.Arrow                as X (first, second)
 import Data.Memory.Internal.DeepSeq as X

--- a/Data/Memory/PtrMethods.hs
+++ b/Data/Memory/PtrMethods.hs
@@ -53,13 +53,11 @@ memXorWith destination !v source bytes
     | destination == source = loopInplace source bytes
     | otherwise             = loop destination source bytes
   where
-    loop _   _  0 = return ()
-    loop !d !s !n = do
+    loop !d !s n = when (n > 0) $ do
         peek s >>= poke d . xor v
         loop (d `plusPtr` 1) (s `plusPtr` 1) (n-1)
 
-    loopInplace _   0 = return ()
-    loopInplace !s !n = do
+    loopInplace !s n = when (n > 0) $ do
         peek s >>= poke s . xor v
         loopInplace (s `plusPtr` 1) (n-1)
 


### PR DESCRIPTION
Arguments 'source' and 'destination' are always evaluated due to the
equality condition.  However in worker functions 'loop' and
'loopInplace' the equations testing n == 0 made evaluation of
arguments 's' and 'd' lazy.

With this patch, optimizations allow to use unboxed pointers and
remove allocation of Ptr values.