### PR TITLE
Warn that other languages may encode Base64 per RFC 2045

### DIFF
--- a/Data/ByteArray/Encoding.hs
+++ b/Data/ByteArray/Encoding.hs
@@ -33,6 +33,13 @@ import           Data.Memory.Encoding.Base64
 -- encoding is often used in other specifications without
 -- <http://tools.ietf.org/html/rfc4648#section-3.2 padding> characters.
 --
+-- <https://www.ietf.org/rfc/rfc2045.txt RFC 2045>
+-- defines a separate Base64 encoding, which is not supported. This format
+-- requires a newline at least every 76 encoded characters, which works around
+-- limitations of older email programs that could not handle long lines.
+-- Be aware that other languages, such as Ruby, encode the RFC 2045 version
+-- by default. To decode their ouput, remove all newlines before decoding.
+--
 -- ==== Examples
 --
 -- A quick example to show the differences:


### PR DESCRIPTION
My coworker just ran into an issue where Base64 decoding failed because his Base64 string had newlines in it. It turns out [Ruby's `encode64`](https://ruby-doc.org/stdlib-2.1.0/libdoc/base64/rdoc/Base64.html#method-i-encode64) complies with RFC 2045, which adds newlines. Some other languages like very old Pythons do this as well.

I thought it might be nice to warn that people may run into this format, and recommend a fix for it (first removing all newlines).