### PR TITLE
Allow Data.ByteArray.Sized to compile without basement support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## HEAD
+
+* Allow the `Data.ByteArray.Sized` module to compile when `basement` support is
+  disabled.
+
 ## 0.14.18
 
 * Branch/Release Snafu

--- a/memory.cabal
+++ b/memory.cabal
@@ -59,6 +59,7 @@ Library
                      Data.ByteArray.Pack
                      Data.ByteArray.Parse
                      Data.ByteArray.Hash
+                     Data.ByteArray.Sized
                      Data.Memory.Endian
                      Data.Memory.PtrMethods
                      Data.Memory.ExtendedWords
@@ -104,7 +105,6 @@ Library
   if flag(support_foundation) || flag(support_basement)
     CPP-options:     -DWITH_BASEMENT_SUPPORT
     Build-depends:   basement >= 0.0.7
-    exposed-modules: Data.ByteArray.Sized
 
   ghc-options:       -Wall -fwarn-tabs
   default-language:  Haskell2010


### PR DESCRIPTION
Allow `Data.ByteArray.Sized` to compile without basement support.

The `pack` and `unpack` functions would not be exported if `basement` is unavailable, but that's a reasonable expectation, considering they come from `basement` =)
