### PR TITLE
Build with GHC 9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 .stack-work
 refs/
 stack.yaml.lock
+dist-newstyle/

--- a/Data/ByteArray/Bytes.hs
+++ b/Data/ByteArray/Bytes.hs
@@ -16,6 +16,9 @@ module Data.ByteArray.Bytes
     ( Bytes
     ) where
 
+#if MIN_VERSION_base(4,15,0)
+import           GHC.Exts (unsafeCoerce#)
+#endif
 import           GHC.Types
 import           GHC.Prim
 import           GHC.Ptr

--- a/Data/ByteArray/ScrubbedBytes.hs
+++ b/Data/ByteArray/ScrubbedBytes.hs
@@ -17,6 +17,9 @@ module Data.ByteArray.ScrubbedBytes
 import           GHC.Types
 import           GHC.Prim
 import           GHC.Ptr
+#if MIN_VERSION_base(4,15,0)
+import           GHC.Exts (unsafeCoerce#)
+#endif
 #if MIN_VERSION_base(4,9,0)
 import           Data.Semigroup
 import           Data.Foldable (toList)


### PR DESCRIPTION
This PR adds support for GHC 9. Apparently the `unsafeCoerce#` function was removed from wherever it was being exported from.