### PR TITLE
Compatibility with GHC 9.4 (base-4.17)

### DIFF
--- a/Data/Memory/Internal/CompatPrim64.hs
+++ b/Data/Memory/Internal/CompatPrim64.hs
@@ -52,6 +52,9 @@ module Data.Memory.Internal.CompatPrim64
 
 
 #if WORD_SIZE_IN_BITS == 64
+#if MIN_VERSION_base(4,17,0)
+import GHC.Prim
+#else
 import GHC.Prim hiding (Word64#, Int64#)
 
 #if __GLASGOW_HASKELL__ >= 708
@@ -143,9 +146,10 @@ word64ToWord# w = w
 
 timesWord64# :: Word64# -> Word64# -> Word64#
 timesWord64# = timesWord#
+#endif
 
 w64# :: Word# -> Word# -> Word# -> Word64#
-w64# w _ _ = w
+w64# w _ _ = wordToWord64# w
 
 #elif WORD_SIZE_IN_BITS == 32
 import GHC.IntWord64


### PR DESCRIPTION
Fixes #94.

Tested using

    cabal test -w ghc-9.4.1

on a 64-bit Linux. I don't have a 32-bit platform available, but if that is going to block the merging of this, I can make a virtual machine.
